### PR TITLE
Explicitly remove powerups on death.

### DIFF
--- a/code/character.js
+++ b/code/character.js
@@ -597,6 +597,7 @@ Mario.Character.prototype.Die = function() {
     this.World.Paused = true;
     this.DeathTime = 1;
     Enjine.Resources.PlaySound("death");
+    this.SetLarge(false, false);
 };
 
 Mario.Character.prototype.GetFlower = function() {


### PR DESCRIPTION
To fix the issue that powerups were kept when you die by falling into a pit.
